### PR TITLE
Fix link to github

### DIFF
--- a/docs/_data/navigation.json
+++ b/docs/_data/navigation.json
@@ -12,7 +12,7 @@
     },
     {
       "text": "GitHub",
-      "url": "https://formally-valid.info",
+      "url": "https://github.com/dgrammatiko/formally",
       "external": true
     }
   ]


### PR DESCRIPTION
Currently you just go to the docs homepage - which is kinda annoying :)